### PR TITLE
repair "ash: missing ]]"

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -1323,7 +1323,7 @@ buildHeaders() {
 
 sendMail() {
     #close email message
-    if [[ "${EMAIL_LOG}" -eq 1 ]] || [[ "${EMAIL_ALERT}" -eq 1]] ; then
+    if [[ "${EMAIL_LOG}" -eq 1 ]] || [[ "${EMAIL_ALERT}" -eq 1 ]] ; then
         SMTP=1
         #validate firewall has email port open for ESXi 5
         if [[ "${VER}" == "5" ]] || [[ "${VER}" == "6" ]] ; then


### PR DESCRIPTION
I get "ash: missing ]]" when the sendMail() function executes, and also "bad number" on the following line
- sendMail
- [[ 0 -eq 1 ]]
- [[ 0 -eq 1]]
  ash: missing ]]
- [[  -eq 1 ]]
  ash: bad number

This takes care of the first one...
